### PR TITLE
Fix React deprecation warning

### DIFF
--- a/src/ADPagination.js
+++ b/src/ADPagination.js
@@ -9,8 +9,8 @@ export default function ADPagination(props){
   let Item = function(props) {
     let className = (props.className) || "";
     return(<li className={"page-item " + className}>
-      <a href='javascript:void(0);' className="page-link" tabIndex="-1"
-        onClick={props.onClick}>
+      <a href='#' className="page-link" tabIndex="-1"
+        onClick={(e) => { e.preventDefault(); props.onClick(e) }}>
         {props.children}
       </a>
     </li>);


### PR DESCRIPTION
```
Warning: A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML try using dangerouslySetInnerHTML instead. React was passed "javascript:void(0);".
    in a (created by Item)
    in li (created by Item)
    in Item (created by ADPagination)
    in ADPagination (created by TableFooter)
    in ul (created by TableFooter)
    in nav (created by TableFooter)
    in div (created by TableFooter)
    in div (created by TableFooter)
    in TableFooter (created by ReactDatatable)
    in div (created by ReactDatatable)
    in ReactDatatable (created by DataTable)
    ...
```